### PR TITLE
Fix/proguard consumer

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -20,7 +20,7 @@ android {
   buildTypes {
     release {
       minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      consumerProguardFiles 'proguard-rules.pro'
     }
     debug {
       debuggable true

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
   // Third party dependencies.
   implementation 'com.google.code.gson:gson:2.8.5'
-  implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+  implementation 'com.squareup.okhttp3:okhttp:3.12.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/sdk/proguard-rules.pro
+++ b/sdk/proguard-rules.pro
@@ -20,12 +20,17 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--dontwarn okhttp3.**
--dontwarn okio.**
+# JSR 305 annotations are for embedding nullability information.
 -dontwarn javax.annotation.**
--dontwarn org.conscrypt.**
+
 # A resource is loaded with a relative path so the package of this class must be preserved.
 -keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
 
 # Remove log methods when compiling production API
 -assumenosideeffects class android.util.Log {


### PR DESCRIPTION
We used "proguardFiles" which is a way to define a proguard config for apps. Since this is an SDK/lib we should have used "consumerProguardFiles".

Version bumped proguard and applied the suggested rules.